### PR TITLE
Pass ECP info to SAD guess

### DIFF
--- a/psi4/driver/qcdb/libmintsbasisset.py
+++ b/psi4/driver/qcdb/libmintsbasisset.py
@@ -943,7 +943,7 @@ class BasisSet(object):
         text += '\n'
 
         if return_atomlist:
-            return atom_basis_list, text, None
+            return atom_basis_list, text, ecpbasisset
         else:
             return basisset, text, ecpbasisset
 


### PR DESCRIPTION
This fixes the SAD guess with ECPs (along with the changes you made already, of course).  The SCF and ECP tests all pass, but I haven't had chance to test beyond that.  Sorry for taking so long to get to this, and thanks to Lori for figuring where the error is.